### PR TITLE
Replace any non-alpha numeric characters to prevent path issues.

### DIFF
--- a/packages/sosia-markdown/MarkdownSource.ts
+++ b/packages/sosia-markdown/MarkdownSource.ts
@@ -13,7 +13,7 @@ export default class MarkdownSource {
         switch (node.type) {
           case 'title':
             const block = node.block[0] as any;
-            title = block && block.text.replace(/[^\w]+/gu, '-');
+            title = block && block.text;
             break;
           case 'codeBlock':
             ex.push({

--- a/packages/sosia-markdown/MarkdownSource.ts
+++ b/packages/sosia-markdown/MarkdownSource.ts
@@ -13,7 +13,7 @@ export default class MarkdownSource {
         switch (node.type) {
           case 'title':
             const block = node.block[0] as any;
-            title = block && block.text;
+            title = block && block.text.replace(/[^\w]+/gu, '-');
             break;
           case 'codeBlock':
             ex.push({

--- a/packages/sosia/jest.ts
+++ b/packages/sosia/jest.ts
@@ -63,8 +63,7 @@ const runTests = (examples: Example[]): void => {
     describe(`snapshot: ${targetName}`, () => {
       examples.forEach((example, i) => {
         const customSnapshotIdentifier = `${targetName} ${example.name}`
-          .split(' ')
-          .join('-')
+          .replace(/[^\w]+/gu, '-')
           .toLowerCase();
 
         test(`${example.name}`, async () => {


### PR DESCRIPTION
This fixes an issue where the Markdown header `### Action Required / Needs Attention` was turned into `action-required-/-needs-attention` and caused a test to fail as it was looking for a folder that doesn't exist.