### PR TITLE
Improved support for components that use hooks

### DIFF
--- a/packages/sosia/change-tracker.ts
+++ b/packages/sosia/change-tracker.ts
@@ -18,7 +18,7 @@ export default ({cachePath, updateSnapshot}: {cachePath: string; updateSnapshot:
 
   const markAsDirty = (key: string) => {
     snapshotState._dirty = true;
-    snapshotState._snapshotData[key] = '__diff__';
+    delete snapshotState._snapshotData[key];
   };
 
   const match = (page: NamedPage) => {
@@ -34,12 +34,6 @@ export default ({cachePath, updateSnapshot}: {cachePath: string; updateSnapshot:
 
     // visual regression should be run on new pages and on pages that have uncommitted changes
     const match = pass && added === snapshotState.added && updated === snapshotState.updated;
-
-    if (!pass) {
-      // if there are uncommitted changes, clear the current hash from the cache to ensure
-      // a new hash is created when the user updates their snapshots
-      markAsDirty(key);
-    }
 
     return !match;
   };

--- a/packages/sosia/package-lock.json
+++ b/packages/sosia/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sosia",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sosia/package-lock.json
+++ b/packages/sosia/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sosia",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sosia/package.json
+++ b/packages/sosia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sosia",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Sosia is a visual regression tool, powered by component snapshots",
   "repository": {
     "type": "git",

--- a/packages/sosia/package.json
+++ b/packages/sosia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sosia",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Sosia is a visual regression tool, powered by component snapshots",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What did we change?

- use ReactDOM.render instead of renderToStaticMarkup as hooks like `useLayoutEffect` do not run in the `react-dom/server` environment.
- fix: clear cache on failed tests
- fix: ensure cache is updated on successful run

## Why are we doing this?

- improve support for react hooks 
- We don't want cached results to block regression tests running on previously failed code paths (especially problematic if the failed code path just needs to be re-run to allow the snapshot update to kick-in)